### PR TITLE
Version 2.4

### DIFF
--- a/inat.label.py
+++ b/inat.label.py
@@ -198,10 +198,8 @@ def extract_observation_id(input_string, debug = False):
     # http://mushroomobserver.org/observations/12345
     # https://mushroomobserver.org/obs/585855
     # https://www.mushroomobserver.org/obs/585855?foo=bar
-    mo_url_match = re.search(
-        r'https?://(?:www\.)?mushroomobserver\.org/(?:observations/|observer/show_observation/|obs/)?(\d+)(?=[/?#]|$)',
-        input_string
-    )
+    mo_url_match = re.search( r'(?:https?://)?(?:www\.)?mushroomobserver\.org/(?:observations/|observer/show_observation/|obs/)?/?(\d+)(?=[/?#\s]|$)',input_string)
+
     if mo_url_match:
         # Return the MO ID with the MO prefix
         return f"MO{mo_url_match.group(1)}"


### PR DESCRIPTION
fix regex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Mushroom Observer IDs from pasted or typed input.
  * Accepts URLs with or without http/https, optional leading slash, and tolerates trailing whitespace.
  * Recognizes shorthand and path formats (e.g., “MO1234”, “mushroomobserver.org/obs/1234”).
  * No changes to user-facing APIs or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->