### PR TITLE
Version 2.5

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,11 +3,11 @@
 
 ## 2.5
 
-- Added --pdf option to save labels in PDF format - more compatibility,
-especially with Mac.
+- Added --pdf option to save labels in PDF format - more compatibility, especially with Mac.   Uses the same font - Liberation Serif.
 - PDF output is in two columns with no margins to fit more labels per page.
 - Labels are kept together and will not split across columns or pages.
 - QR codes in PDF are placed intelligently to save space. For short notes, the QR code is to the right of the notes. For long notes, it is below.
+- Removed the iNaturalist URL: header because it's already obvious that it's an iNaturalist URL.
 
 ## 2.4
 

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## 2.5
+
+- Added --pdf option to save labels in PDF format - more compatibility,
+especially with Mac.
+- PDF output is in two columns with no margins to fit more labels per page.
+- Labels are kept together and will not split across columns or pages.
+- QR codes in PDF are placed intelligently to save space. For short notes, the QR code is to the right of the notes. For long notes, it is below.
+
 ## 2.4
 
 Now checks for the Species Name Override observation field - if present it

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # inat.label.py
 
-# iNaturalist Herbarium Label Generator version 2.4
+# iNaturalist Herbarium Label Generator version 2.5
 # By Alan Rockefeller
-# September 4, 2025
+# September 23, 2025
 
 
 ## Description
@@ -49,6 +49,7 @@ An easy to use online version is at https://images.mushroomobserver.org/labels
   - Observation Notes
 - By default outputs labels to console for quick viewing / testing
 - Optionally creates formatted RTF files for high-quality printing (RTF output is strongly recommended)
+- Optionally creates two-column PDF files for more compatability
 - Handles special characters and formatting (e.g., italics for scientific names, proper display of ± symbol)
 - An optional command line switch can print out the iNaturalist URL's of observations which are in California.   This makes it easy to add these observations to the Mycomap CA Network project.
 - Includes a 1-second delay if there are more than 20 requests, which stops the iNaturalist API from denying requests for large label printing jobs.
@@ -72,7 +73,7 @@ Instead of installing this software, consider using the online version: https://
 
 3. Install the required dependencies:
    ```
-   bash pip install requests python-dateutil beautifulsoup4 qrcode[pil] colorama replace-accents pillow
+   bash pip install requests python-dateutil beautifulsoup4 qrcode[pil] colorama replace-accents pillow reportlab
    ```
 
 ## Usage
@@ -87,6 +88,12 @@ To generate an RTF file, use the `--rtf` option:
 
 ```
 python inat.label.py <observation_number_or_url> [<observation_number_or_url> ...] --rtf <filename.rtf>
+```
+
+To generate a PDF file, use the `--pdf` option:
+
+```
+python inat.label.py <observation_number_or_url> [<observation_number_or_url> ...] --pdf <filename.pdf>
 ```
 
 To print out a list of URL's of observations that are in California, use the `--find-ca` option.    This was added to make it easy to add observations to the Mycomap CA Network project.   I paste the list of URL's into the Bulk URL Opener Chrome extension and add each tab to the project.   If there is an easier way, I haven't found it yet.
@@ -126,6 +133,7 @@ The script generates herbarium labels to the standard output by default, or labe
 - colorama
 - replace-accents
 - pillow
+- reportlab
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ An easy to use online version is at https://images.mushroomobserver.org/labels
   - Observation Notes
 - By default outputs labels to console for quick viewing / testing
 - Optionally creates formatted RTF files for high-quality printing (RTF output is strongly recommended)
-- Optionally creates two-column PDF files for more compatability
+- Optionally creates two-column PDF files for more compatibility
 - Handles special characters and formatting (e.g., italics for scientific names, proper display of ± symbol)
 - An optional command line switch can print out the iNaturalist URL's of observations which are in California.   This makes it easy to add these observations to the Mycomap CA Network project.
 - Includes a 1-second delay if there are more than 20 requests, which stops the iNaturalist API from denying requests for large label printing jobs.

--- a/inat.label.py
+++ b/inat.label.py
@@ -86,6 +86,15 @@ from reportlab.lib.enums import TA_LEFT
 from reportlab.lib.units import inch
 from reportlab.lib.colors import black, blue, green, white
 from reportlab.lib.utils import ImageReader
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+pdfmetrics.registerFont(TTFont('Liberation Serif', 'LiberationSerif-Regular.ttf'))
+pdfmetrics.registerFont(TTFont('Liberation Serif-Bold', 'LiberationSerif-Bold.ttf'))
+pdfmetrics.registerFont(TTFont('Liberation Serif-Italic', 'LiberationSerif-Italic.ttf'))
+pdfmetrics.registerFont(TTFont('Liberation Serif-BoldItalic', 'LiberationSerif-BoldItalic.ttf'))
+pdfmetrics.registerFontFamily('Liberation Serif', normal='Liberation Serif', bold='Liberation Serif-Bold', italic='Liberation Serif-Italic', boldItalic='Liberation Serif-BoldItalic')
+
 
 
 
@@ -743,7 +752,7 @@ def create_inaturalist_label(observation_data, iconic_taxon_name, rtf_mode=False
     else:
         # For iNaturalist data
         label.extend([
-            ("iNat Observation Number", str(obs_number)),
+            ("iNaturalist Observation Number", str(obs_number)),
             ("iNaturalist URL", url),
             ("Location", location),
             ("GPS Coordinates", gps_coords),
@@ -851,6 +860,7 @@ def create_pdf_content(labels, filename):
     custom_normal_style = ParagraphStyle(
         'CustomNormal',
         parent=styles['Normal'],
+        fontName='Liberation Serif',
         fontSize=12,
         leading=14
     )
@@ -884,6 +894,9 @@ def create_pdf_content(labels, filename):
                 continue
             if field == "Scientific Name":
                 p = Paragraph(f"<b>{field}:</b> <i>{value}</i>", custom_normal_style)
+                pre_notes_content.append(p)
+            elif field == "iNaturalist URL":
+                p = Paragraph(f"{value}", custom_normal_style)
                 pre_notes_content.append(p)
             else:
                 p = Paragraph(f"<b>{field}:</b> {value}", custom_normal_style)
@@ -966,7 +979,9 @@ def create_rtf_content(labels):
                 None)
 
             for field, value in label:
-                if field.startswith("iNat") or field.startswith("iNaturalist") or field.startswith("Mushroom Observer"):
+                if field == "iNaturalist URL":
+                    rtf_content += str(value) + r"\line "
+                elif field.startswith("iNat") or field.startswith("iNaturalist") or field.startswith("Mushroom Observer"):
                     # Special formatting for observation headers
                     if field.startswith("Mushroom Observer"):
                         first_chars, rest = field[:2], field[2:]
@@ -1158,7 +1173,11 @@ if __name__ == "__main__":
                             value = remove_formatting_tags(value)
                             value = re.sub(r'Originally posted to Mushroom Observer on [A-Za-z]+\. \d{1,2}, \d{4}\.', '', value)
                             value = re.sub(r'Imported by Mushroom Observer \d{4}-\d{2}-\d{2}', '', value)
-                        print(f"{field}: {value}")
+                            print(f"{field}: {value}")
+                        elif field == "iNaturalist URL":
+                            print(value)
+                        else:
+                            print(f"{field}: {value}")
                     print("\n")  # Blank line between labels
         else:
             print("No valid observations found.")


### PR DESCRIPTION
- Added --pdf option to save labels in PDF format - more compatibility, especially with Mac.   Uses the same font - Liberation Serif.
- PDF output is in two columns with no margins to fit more labels per page.
- Labels are kept together and will not split across columns or pages.
- QR codes in PDF are placed intelligently to save space. For short notes, the QR code is to the right of the notes. For long notes, it is below.
- Removed the iNaturalist URL: header because it's already obvious that it's an iNaturalist URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add PDF label output with a two‑column, marginless layout, serif font, and space‑efficient QR codes.
  - New --pdf CLI option (mutually exclusive with --rtf) to generate PDF labels.
  - Keeps labels intact across columns/pages and removes the iNaturalist URL header from labels.
- Improvements
  - Updated label header wording to “iNaturalist Observation Number.”
  - When printing to stdout, URLs are printed directly if present.
- Documentation
  - Updated README for v2.5, PDF capability, examples, and installation.
- Chores
  - Added a new dependency required for PDF generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->