### PR TITLE
Version 3.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1 
+November 6, 2025
+- Add the --no-qr command line option to optionally omit QR codes.   Suggested by James Mickley, who commented that QR codes can confuse herbarium digitization systems like the one used at the Oregon State herbarium.
+
+## 3.0
+November 3, 2025
+- Don't print common names unless --common-names argument is given
+- Make sure there aren't any extra blank spaces in RTF labels
 
 ## 2.9
 October 24, 2025

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # inat.label.py
 
-# iNaturalist Herbarium Label Generator version 3.0
+# iNaturalist Herbarium Label Generator version 3.1
 # By Alan Rockefeller
-# November 3, 2025
+# November 6, 2025
 
 
 ## Description
@@ -54,7 +54,8 @@ An easy to use online version is at https://images.mushroomobserver.org/labels
 - Handles special characters and formatting (e.g., italics for scientific names, proper display of ± symbol)
 - An optional command line switch can print out the iNaturalist URL's of observations which are in California.   This makes it easy to add these observations to the Mycomap CA Network project.
 - Adds a QR code to the PDF and RTF labels which points to the iNaturalist URL
-- When generating RTF labels it prints the iconic taxon along with the name - fungi in blue, plants in green and everything else in white.   This will help you quickly notice if an observation number is mistyped.
+- When generating PDF or RTF labels it prints the iconic taxon along with the name - fungi in blue, plants in green and everything else in white.   This will help you quickly notice if an observation number is mistyped.
+- You can use the --no-qr command line option to omit QR codes.
 
 ## Installation
 


### PR DESCRIPTION
- Add the --no-qr command line option to optionally omit QR codes.   Suggested by James Mickley, who commented that QR codes can confuse herbarium digitization systems like the one used at the Oregon State herbarium.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `--no-qr` option to omit QR codes from generated labels in PDF and RTF formats.
* Version 3.0 improvements: Made common names display optional with `--common-names` flag; removed extra blank spaces in RTF labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->