### PR TITLE
Adding option to use a field for a label title

### DIFF
--- a/inat.label.py
+++ b/inat.label.py
@@ -1811,6 +1811,11 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    # User can not use 'Notes" as title field
+    if args.title == "Notes":
+        parser.error("argument --title: 'Notes' field can not be used as title")
+        sys.exit(1)
+
     # Define rtf_mode and pdf_mode based on whether --rtf or --pdf argument is provided
     rtf_mode = bool(args.rtf)
     pdf_mode = bool(args.pdf)


### PR DESCRIPTION
Adding a option to choose to use one field by name as a label title.  This will move the field value from the label text and use it as a label title, center in bold.  This is a feature only for pdf labels at this time.

Also added the possible field "accession number" from iNat observation to be used in labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF labels can render a chosen field as a centered, bold title (use via the --title option).
  * Accession Number field is included on generated labels for improved specimen tracking.
  * Mushroom Observer URLs are normalized when added to labels.
  * PDF generation detects non-ASCII text and switches to a system Unicode font when available to preserve characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->