### PR TITLE
Label sorting and stack ordering

### DIFF
--- a/inat.label.py
+++ b/inat.label.py
@@ -1377,12 +1377,7 @@ def create_pdf_content(labels, filename, no_qr=False, title_field=None, fungus_f
 
     Expects labels as an iterable of (label_fields, iconic_taxon_name). Adds a QR code when a URL is present.
     """
-    doc = BaseDocTemplate(filename, 
-                          pagesize=letter, 
-                          leftMargin=0.25*inch, 
-                          rightMargin=0.25*inch, 
-                          topMargin=0.12*inch, 
-                          bottomMargin=0.12*inch)
+   
     register_fonts()
     if fungus_fair_mode:
         try:
@@ -1391,7 +1386,9 @@ def create_pdf_content(labels, filename, no_qr=False, title_field=None, fungus_f
             print_error("Error: PIL (Pillow) is required for fungus fair mode image handling.")
             sys.exit(1)
 
-    doc = BaseDocTemplate(filename, pagesize=letter, leftMargin=0.25*inch, rightMargin=0.25*inch, topMargin=0.25*inch, bottomMargin=0.25*inch)
+    doc = BaseDocTemplate(filename, pagesize=letter, 
+                          leftMargin=0.25*inch, rightMargin=0.25*inch, 
+                          topMargin=0.12*inch, bottomMargin=0.12*inch)
 
     # Two columns
     column_gap = 0.5 * inch # Must be twice the margin to cut labels that are the same size


### PR DESCRIPTION
This PR adds label sorting, so the labels will be in order, be default, of iNat obs. number and/or MO obs. number.  If a title field is used, then the labels are sorted by the title field.

This PR also adds "stack-order" as an option.  This will order the labels so that when you cut them, by first cutting the stack in half length-wise, then cutting the stacks from the bottom to the top, the result cut labels will be in order.  This option doesn't work with mini-labels, but could be changed to add that if desired.

Also there are small tweaks on the margins to make it easy to cut labels, so the margins don't have to be trimmed first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to enable stacked multi-page label ordering; stacking fills pages as needed.
  * Labels now default to sorting by Observation Number, with an option to sort by a specified title field.

* **Improvements**
  * Adjusted PDF layout spacing and increased column gutter for better print layout.
  * Sorting and stacking are applied before final rendering for consistent output.

* **Bug Fixes**
  * Validation prevents using stacking together with the mini-label mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->